### PR TITLE
Fix git-added color

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -32,7 +32,6 @@
 @syntax-gutter-background-color-selected: #1d3b53;
 
 /* For git diff info. i.e. in the gutter */
-@syntax-color-added: #011627;
+@syntax-color-added: #9ccc65;
 @syntax-color-modified: #e2b93d;
-@syntax-color-renamed: #9ccc65;
 @syntax-color-removed: #ef5350;


### PR DESCRIPTION
`@syntax-color-renamed` wasn't being used by the [git-diff package](https://github.com/atom/atom/blob/master/packages/git-diff/styles/git-diff.less).
`@syntax-color-added` had the value of `editorGutter.background` from [the original night owl](https://github.com/sdras/night-owl-vscode-theme/blob/master/themes/Night%20Owl-color-theme.json#L111-L114), but it should have `editorGutter.addedBackground`.

Closes #2 