### PR TITLE
💅  Add background color to find selections

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -41,6 +41,18 @@ atom-text-editor .search-results .syntax--marker.current-result .region {
   border: @syntax-result-marker-color-selected;
 }
 
+atom-text-editor .find-result .region {
+  background-color: @syntax-result-marker-background;
+  border: none;
+  border-radius: 0;
+}
+
+atom-text-editor .current-result .region {
+  background-color: @syntax-result-marker-background-selected;
+  border: none;
+  border-radius: 0;
+}
+
 atom-text-editor.is-focused .cursor {
   border-color: @syntax-cursor-color;
 }

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -22,6 +22,8 @@
 @syntax-invisible-character-color: rgba(255, 255, 255, 0.2);
 
 /* For find and replace markers */
+@syntax-result-marker-background: #2e3248;
+@syntax-result-marker-background-selected: rgba(95, 126, 150, 0.79);
 @syntax-result-marker-color: #1d3b53;
 @syntax-result-marker-color-selected: #1d3b53;
 


### PR DESCRIPTION
Pulls the find colors from the [source theme](https://github.com/sdras/night-owl-vscode-theme/blob/master/themes/Night%20Owl-color-theme.json#L89-L90).

I've also removed the borders since the original theme doesn't contain them, and they were quite on-the-nose over the selection.

Closes #3 